### PR TITLE
IOC - Reflections

### DIFF
--- a/src/main/java/com/github/racc/tscg/TypesafeConfigModule.java
+++ b/src/main/java/com/github/racc/tscg/TypesafeConfigModule.java
@@ -72,21 +72,28 @@ public class TypesafeConfigModule extends AbstractModule {
 	 * @return The constructed TypesafeConfigModule.
 	 */
 	public static TypesafeConfigModule fromConfigWithPackage(Config config, String packageNamePrefix) {
-		 ConfigurationBuilder configBuilder = 
-			 new ConfigurationBuilder()
-	         .filterInputsBy(new FilterBuilder().includePackage(packageNamePrefix))
-	         .setUrls(ClasspathHelper.forPackage(packageNamePrefix))
-	         .setScanners(
-	        	new TypeAnnotationsScanner(), 
-	        	new MethodParameterScanner(), 
-	        	new MethodAnnotationsScanner(), 
-	        	new FieldAnnotationsScanner()
-	         );
-		Reflections reflections = new Reflections(configBuilder);
-		
+		Reflections reflections = createPackageScanningReflections(packageNamePrefix);
+		return fromConfigWithReflections(config, reflections);
+	}
+
+	public static TypesafeConfigModule fromConfigWithReflections(Config config, Reflections reflections) {
 		return new TypesafeConfigModule(config, reflections);
 	}
-	
+
+	public static Reflections createPackageScanningReflections(String packageNamePrefix){
+		ConfigurationBuilder configBuilder =
+				new ConfigurationBuilder()
+						.filterInputsBy(new FilterBuilder().includePackage(packageNamePrefix))
+						.setUrls(ClasspathHelper.forPackage(packageNamePrefix))
+						.setScanners(
+								new TypeAnnotationsScanner(),
+								new MethodParameterScanner(),
+								new MethodAnnotationsScanner(),
+								new FieldAnnotationsScanner()
+						);
+		return new Reflections(configBuilder);
+	}
+
 	@SuppressWarnings({ "rawtypes"})
 	@Override
 	protected void configure() {


### PR DESCRIPTION
This pull request applies the IOC principle to construction of TypesafeConfigModules.

Yielding control of the Reflections object used by TypesafeConfigModule affords users flexiblity. For example, the flexibility to filter by excluded packages or to include multiple package prefixes, or the flexibility to reuse the Reflections object in a large parameterized integration test suite without rescanning the entire classpath for each test.