### PR TITLE
Allow for use of fast-classpath-scanner instead of reflections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,8 @@ uploadArchives {
 
 dependencies {
 	compile 'com.typesafe:config:1.3.0'
-	compile 'org.reflections:reflections:0.9.9'
+    compile group: 'io.github.lukehutch', name: 'fast-classpath-scanner', version: '2.18.1'
+    compile 'org.reflections:reflections:0.9.9'
 	compile 'com.google.inject:guice:4.0:no_aop'
 	
 	testCompile 'junit:junit:4.12'

--- a/src/main/java/com/github/racc/tscg/Reflector.java
+++ b/src/main/java/com/github/racc/tscg/Reflector.java
@@ -1,0 +1,12 @@
+package com.github.racc.tscg;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public interface Reflector {
+    Set<Constructor> getConstructorsWithAnyParamAnnotated(Class<?> clazz);
+    Set<Method> getMethodsWithAnyParamAnnotated(Class<?> clazz);
+    Set<Field> getFieldsAnnotatedWith(Class<?> clazz);
+}

--- a/src/main/java/com/github/racc/tscg/TypesafeConfigModule.java
+++ b/src/main/java/com/github/racc/tscg/TypesafeConfigModule.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.racc.tscg.reflectors.fastclasspathscanner.FastClasspathScanningReflector;
+import com.github.racc.tscg.reflectors.reflections.ReflectionsReflector;
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import org.reflections.Reflections;
 import org.reflections.scanners.FieldAnnotationsScanner;
 import org.reflections.scanners.MethodAnnotationsScanner;
@@ -41,10 +44,10 @@ import com.typesafe.config.ConfigValueType;
 public class TypesafeConfigModule extends AbstractModule {
 
 	private final Config config;
-	private final Reflections reflections;
+	private final Reflector reflections;
 	private final Set<TypesafeConfig> boundAnnotations;
 
-	private TypesafeConfigModule(Config config, Reflections reflections) {
+	private TypesafeConfigModule(Config config, Reflector reflections) {
 		this.config = config;
 		this.reflections = reflections;
 		this.boundAnnotations = new HashSet<TypesafeConfig>();
@@ -84,7 +87,18 @@ public class TypesafeConfigModule extends AbstractModule {
 	         );
 		Reflections reflections = new Reflections(configBuilder);
 		
-		return new TypesafeConfigModule(config, reflections);
+		return new TypesafeConfigModule(config, new ReflectionsReflector(reflections));
+	}
+
+
+	/**
+	 * Scans the specified packages for annotated classes, and applies Config values to them.
+	 *
+	 * @param config the Config to derive values from
+	 * @return The constructed TypesafeConfigModule.
+	 */
+	public static TypesafeConfigModule fromConfigUsingClasspathScanner(Config config, String ...scannerSpec) {
+		return new TypesafeConfigModule(config, new FastClasspathScanningReflector(scannerSpec));
 	}
 	
 	@SuppressWarnings({ "rawtypes"})

--- a/src/main/java/com/github/racc/tscg/reflectors/fastclasspathscanner/FastClasspathScanningReflector.java
+++ b/src/main/java/com/github/racc/tscg/reflectors/fastclasspathscanner/FastClasspathScanningReflector.java
@@ -1,0 +1,112 @@
+package com.github.racc.tscg.reflectors.fastclasspathscanner;
+
+import com.github.racc.tscg.Reflector;
+import com.github.racc.tscg.TypesafeConfig;
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import io.github.lukehutch.fastclasspathscanner.scanner.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+
+public class FastClasspathScanningReflector implements Reflector {
+
+    private final ScanResult scanResult;
+    private final FastClasspathScanner scanner;
+
+    public FastClasspathScanningReflector(String ...scannerSpec) {
+        this.scanner = new FastClasspathScanner(scannerSpec).enableMethodInfo().enableFieldInfo().ignoreFieldVisibility().ignoreMethodVisibility();
+        this.scanResult = scanner.scan();
+    }
+
+    @Override
+    public Set<Constructor> getConstructorsWithAnyParamAnnotated(Class clazz) {
+        Map<String, ClassInfo> classInfos = scanResult.getClassNameToClassInfo();
+        Set<MethodIdentifier> methodIdentifiers = new HashSet<>();
+        for (ClassInfo classInfo : classInfos.values()){
+            for (MethodInfo methodInfo : classInfo.getMethodAndConstructorInfo()) {
+                if (methodInfo.isConstructor()) {
+                        AnnotationInfo[][] parametersAnnotationInfo = methodInfo.getParameterAnnotationInfo();
+                        if (parametersAnnotationInfo != null)
+                        for (AnnotationInfo[] oneParametersAnnotationInfo: parametersAnnotationInfo) {
+                            for (AnnotationInfo ai : oneParametersAnnotationInfo) {
+                                if (ai.getAnnotationType() == clazz) {
+                                    methodIdentifiers.add(new MethodIdentifier(methodInfo.getClassName(), methodInfo.getMethodName(), methodInfo.getParameterTypeSignatures()));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Set<Constructor> constructors = new HashSet<>(methodIdentifiers.size());
+        for (MethodIdentifier methodIdentifier : methodIdentifiers)
+        {
+            Class<?> classe = scanResult.classNameToClassRef(methodIdentifier.getClassName());
+            for (Constructor<?> constructor : classe.getConstructors()) {
+                if (methodIdentifier.matchesConstructor(classe, constructor, scanResult)){
+                    constructors.add(constructor);
+                }
+            }
+
+        }
+        return constructors;
+    }
+
+    @Override
+    public Set<Method> getMethodsWithAnyParamAnnotated(Class clazz) {
+        Map<String, ClassInfo> classInfos = scanResult.getClassNameToClassInfo();
+        Set<MethodIdentifier> methodIdentifiers = new HashSet<>();
+        for (ClassInfo classInfo : classInfos.values()){
+            for (MethodInfo methodInfo : classInfo.getMethodAndConstructorInfo()) {
+                    AnnotationInfo[][] parametersAnnotationInfo = methodInfo.getParameterAnnotationInfo();
+                    if (parametersAnnotationInfo != null)
+                        for (AnnotationInfo[] oneParametersAnnotationInfo: parametersAnnotationInfo) {
+                            for (AnnotationInfo ai : oneParametersAnnotationInfo) {
+                                if (ai.getAnnotationType() == clazz) {
+                                    methodIdentifiers.add(new MethodIdentifier(methodInfo.getClassName(), methodInfo.getMethodName(), methodInfo.getParameterTypeSignatures()));
+                                }
+                            }
+                        }
+                }
+        }
+        Set<Method> methods = new HashSet<>(methodIdentifiers.size());
+        for (MethodIdentifier methodIdentifier : methodIdentifiers) {
+            Class<?> classe = scanResult.classNameToClassRef(methodIdentifier.getClassName());
+            for (Method method : classe.getDeclaredMethods()) {
+                if (methodIdentifier.matchesMethod(classe, method, scanResult)){
+                    methods.add(method);
+                }
+            }
+        }
+        return methods;
+    }
+
+    @Override
+    public Set<Field> getFieldsAnnotatedWith(Class clazz) {
+        Map<String, ClassInfo> classInfos = scanResult.getClassNameToClassInfo();
+        Set<FieldIdentifier> fieldIdentifiers = new HashSet<>();
+        for (ClassInfo classInfo : classInfos.values()){
+            for (FieldInfo fieldInfo : classInfo.getFieldInfo()) {
+                    List<AnnotationInfo> fieldsAnnotationInfos = fieldInfo.getAnnotationInfo();
+                        for (AnnotationInfo oneFieldAnnotation: fieldsAnnotationInfos) {
+                                if (oneFieldAnnotation.getAnnotationType() == clazz) {
+                                    fieldIdentifiers.add(new FieldIdentifier(fieldInfo.getClassName(), fieldInfo.getFieldName(), fieldInfo.getType()));
+                                }
+
+                        }
+                }
+            }
+        Set<Field> fields = new HashSet<>(fieldIdentifiers.size());
+        for (FieldIdentifier fieldIdentifier : fieldIdentifiers) {
+            Class<?> classe = scanResult.classNameToClassRef(fieldIdentifier.getClassName());
+            for (Field field : classe.getDeclaredFields()) {
+                if (fieldIdentifier.matchesField(classe, field)){
+                    fields.add(field);
+                }
+            }
+        }
+        return fields;
+    }
+
+}

--- a/src/main/java/com/github/racc/tscg/reflectors/fastclasspathscanner/FieldIdentifier.java
+++ b/src/main/java/com/github/racc/tscg/reflectors/fastclasspathscanner/FieldIdentifier.java
@@ -1,0 +1,32 @@
+package com.github.racc.tscg.reflectors.fastclasspathscanner;
+
+import java.lang.reflect.Field;
+
+public class FieldIdentifier {
+    private final String className;
+    private final String fieldName;
+    private final Class<?> fieldType;
+
+    public FieldIdentifier(String className, String fieldName,  Class<?> fieldType) {
+        this.className = className;
+        this.fieldName = fieldName;
+        this.fieldType = fieldType;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public  Class<?> getFieldType() {
+        return fieldType;
+    }
+
+    public boolean matchesField(Class<?> clazz, Field field) {
+       return (clazz.getCanonicalName().equals(className) && field.getName().equals(fieldName) && field.getType() == fieldType);
+    }
+
+}

--- a/src/main/java/com/github/racc/tscg/reflectors/fastclasspathscanner/MethodIdentifier.java
+++ b/src/main/java/com/github/racc/tscg/reflectors/fastclasspathscanner/MethodIdentifier.java
@@ -1,0 +1,57 @@
+package com.github.racc.tscg.reflectors.fastclasspathscanner;
+
+import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
+import io.github.lukehutch.fastclasspathscanner.typesignature.TypeSignature;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+public class MethodIdentifier {
+    private final String className;
+    private final String methodName;
+    private final TypeSignature[] parameterTypeSignature;
+
+    public MethodIdentifier(String className, String methodName, TypeSignature[] parameterTypeSignature) {
+        this.className = className;
+        this.methodName = methodName;
+        this.parameterTypeSignature = parameterTypeSignature;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public TypeSignature[] getParameterTypeSignature() {
+        return parameterTypeSignature;
+    }
+
+    public boolean matchesMethod(Class<?> clazz, Method method, ScanResult scanResult) {
+        if (clazz.getName().equals(className)
+                && method.getName().equals(methodName)
+                && method.getParameterCount() == parameterTypeSignature.length)
+        {
+            boolean paramsMatch = true;
+            for (int i = 0; i < parameterTypeSignature.length; i++) {
+                paramsMatch = paramsMatch && parameterTypeSignature[i].instantiate(scanResult) == method.getParameters()[i].getType();
+            }
+            return paramsMatch;
+        }
+        return false;
+    }
+
+    public boolean matchesConstructor(Class<?> clazz, Constructor<?> constructor, ScanResult scanResult) {
+        if (clazz.getCanonicalName().equals(className) && methodName.equals("<init>") && constructor.getParameterCount() == parameterTypeSignature.length)
+        {
+            boolean paramsMatch = true;
+            for (int i = 0; i < parameterTypeSignature.length; i++) {
+                paramsMatch = paramsMatch && parameterTypeSignature[i].instantiate(scanResult) == constructor.getParameters()[i].getType();
+            }
+            return paramsMatch;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/github/racc/tscg/reflectors/reflections/ReflectionsReflector.java
+++ b/src/main/java/com/github/racc/tscg/reflectors/reflections/ReflectionsReflector.java
@@ -1,0 +1,33 @@
+package com.github.racc.tscg.reflectors.reflections;
+
+import com.github.racc.tscg.Reflector;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+public class ReflectionsReflector implements Reflector {
+
+    private final Reflections delegate;
+
+    public ReflectionsReflector(Reflections delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Set<Constructor> getConstructorsWithAnyParamAnnotated(Class clazz) {
+        return delegate.getConstructorsWithAnyParamAnnotated(clazz);
+    }
+
+    @Override
+    public Set<Method> getMethodsWithAnyParamAnnotated(Class clazz) {
+        return delegate.getMethodsWithAnyParamAnnotated(clazz);
+    }
+
+    @Override
+    public Set<Field> getFieldsAnnotatedWith(Class clazz) {
+        return delegate.getFieldsAnnotatedWith(clazz);
+    }
+}

--- a/src/test/java/com/github/racc/tscg/TypesafeConfigModuleTest.java
+++ b/src/test/java/com/github/racc/tscg/TypesafeConfigModuleTest.java
@@ -4,9 +4,11 @@ package com.github.racc.tscg;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.google.inject.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,23 +19,16 @@ import com.github.racc.tscg.test.MethodInjectedPojo;
 import com.github.racc.tscg.test.NestedPojo;
 import com.github.racc.tscg.test.ProvidedPojo;
 import com.github.racc.tscg.test.TestPojo;
-import com.google.inject.AbstractModule;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigMemorySize;
 
 public class TypesafeConfigModuleTest {
 
-	private Injector injector;
+	private List<Injector> injectors = new LinkedList<>();
 
-	@Before
-	public void setup() {
-		Config testConf = ConfigFactory.load("conf/test.conf");
+	private Module createTestModule() {
+
 		Module testModule = new AbstractModule() {
 			@Override
 			protected void configure() {
@@ -41,64 +36,83 @@ public class TypesafeConfigModuleTest {
 				bind(FieldInjectedPojo.class).asEagerSingleton();
 				bind(MethodInjectedPojo.class).asEagerSingleton();
 			}
-			
+
 			@Provides
 			@Singleton
-			ProvidedPojo providePojo( 
-				@TypesafeConfig("provided.boolean") 	  boolean testBoolean,                  
-				@TypesafeConfig("provided.yesBoolean") 	  boolean testYesBoolean,               
-				@TypesafeConfig("provided.long") 		  long testLong,                        
-				@TypesafeConfig("provided.byte") 		  byte testByte,                        
-				@TypesafeConfig("provided.int") 		  int testInt,                          
-				@TypesafeConfig("provided.double") 		  double testDouble,                    
-				@TypesafeConfig("provided.float") 		  float testFloat,                      
-				@TypesafeConfig("provided.string") 		  String testString,                    
-				@TypesafeConfig("provided.list.boolean")  List<Boolean> testListOfBoolean,      
-				@TypesafeConfig("provided.list.integer")  List<Integer> testListOfInteger,      
-				@TypesafeConfig("provided.list.double")   List<Double> testListOfDouble,        
-				@TypesafeConfig("provided.list.long") 	  List<Long> testListOfLong,            
-				@TypesafeConfig("provided.list.string")   List<String> testListOfString,        
-				@TypesafeConfig("provided.list.duration") List<Duration> testListOfDuration,    
-				@TypesafeConfig("provided.list.size") 	  List<ConfigMemorySize> testListOfSize,
-				@TypesafeConfig("provided.list.nested")   List<NestedPojo> testListOfNested,    
-				@TypesafeConfig("provided.duration") 	  Duration testDuration,                
-				@TypesafeConfig("provided.size") 		  ConfigMemorySize testSize,            
-				@TypesafeConfig("provided.map") 		  Map<String, Integer> testMap,         
-				@TypesafeConfig("provided.map.intkey") 	  Map<Integer, String> testMapIntkey,   
-				@TypesafeConfig("provided.nested") 		  NestedPojo testNestedPojo             
+			ProvidedPojo providePojo(
+					@TypesafeConfig("provided.boolean") 	  boolean testBoolean,
+					@TypesafeConfig("provided.yesBoolean") 	  boolean testYesBoolean,
+					@TypesafeConfig("provided.long") 		  long testLong,
+					@TypesafeConfig("provided.byte") 		  byte testByte,
+					@TypesafeConfig("provided.int") 		  int testInt,
+					@TypesafeConfig("provided.double") 		  double testDouble,
+					@TypesafeConfig("provided.float") 		  float testFloat,
+					@TypesafeConfig("provided.string") 		  String testString,
+					@TypesafeConfig("provided.list.boolean")  List<Boolean> testListOfBoolean,
+					@TypesafeConfig("provided.list.integer")  List<Integer> testListOfInteger,
+					@TypesafeConfig("provided.list.double")   List<Double> testListOfDouble,
+					@TypesafeConfig("provided.list.long") 	  List<Long> testListOfLong,
+					@TypesafeConfig("provided.list.string")   List<String> testListOfString,
+					@TypesafeConfig("provided.list.duration") List<Duration> testListOfDuration,
+					@TypesafeConfig("provided.list.size") 	  List<ConfigMemorySize> testListOfSize,
+					@TypesafeConfig("provided.list.nested")   List<NestedPojo> testListOfNested,
+					@TypesafeConfig("provided.duration") 	  Duration testDuration,
+					@TypesafeConfig("provided.size") 		  ConfigMemorySize testSize,
+					@TypesafeConfig("provided.map") 		  Map<String, Integer> testMap,
+					@TypesafeConfig("provided.map.intkey") 	  Map<Integer, String> testMapIntkey,
+					@TypesafeConfig("provided.nested") 		  NestedPojo testNestedPojo
 			) {
 				return new ProvidedPojo(testBoolean, testYesBoolean, testLong, testByte, testInt, testDouble, testFloat, testString, testListOfBoolean, testListOfInteger, testListOfDouble, testListOfLong, testListOfString, testListOfDuration, testListOfSize, testListOfNested, testDuration, testSize, testMap, testMapIntkey, testNestedPojo);
 			}
+
 		};
-		
-		injector = Guice.createInjector(
-			TypesafeConfigModule.fromConfigWithPackage(testConf, "com.github.racc"),
-			testModule
-		);
+		return testModule;
 	}
-	
+	@Before
+	public void setup() {
+		Config testConf = ConfigFactory.load("conf/test.conf");
+
+
+		injectors.add(Guice.createInjector(
+			TypesafeConfigModule.fromConfigWithPackage(testConf, "com.github.racc"),
+				createTestModule()
+		));
+		injectors.add(Guice.createInjector(
+				TypesafeConfigModule.fromConfigUsingClasspathScanner(testConf, "com.github.racc"),
+				createTestModule()
+		));
+	}
+
 	@Test
 	public void canInjectPojoViaConstructor() {
-		ConstructorInjectedPojo pojo = injector.getInstance(ConstructorInjectedPojo.class);
-		assertPojoIsCorrect(pojo);
+		for (Injector injector : injectors) {
+			ConstructorInjectedPojo pojo = injector.getInstance(ConstructorInjectedPojo.class);
+			assertPojoIsCorrect(pojo);
+		}
 	}
 
 	@Test
 	public void canInjectPojoViaFields() {
-		FieldInjectedPojo pojo = injector.getInstance(FieldInjectedPojo.class);
-		assertPojoIsCorrect(pojo);
+		for (Injector injector : injectors) {
+			FieldInjectedPojo pojo = injector.getInstance(FieldInjectedPojo.class);
+			assertPojoIsCorrect(pojo);
+		}
 	}
 
 	@Test
 	public void canInjectPojoViaMethods() {
-		MethodInjectedPojo pojo = injector.getInstance(MethodInjectedPojo.class);
-		assertPojoIsCorrect(pojo);
+		for (Injector injector : injectors) {
+			MethodInjectedPojo pojo = injector.getInstance(MethodInjectedPojo.class);
+			assertPojoIsCorrect(pojo);
+		}
 	}
 
 	@Test
 	public void canGetProvidedPojo() {
-		ProvidedPojo pojo = injector.getInstance(ProvidedPojo.class);
-		assertPojoIsCorrect(pojo);
+		for (Injector injector : injectors) {
+			ProvidedPojo pojo = injector.getInstance(ProvidedPojo.class);
+			assertPojoIsCorrect(pojo);
+		}
 	}
 
 	private void assertPojoIsCorrect(TestPojo pojo) {


### PR DESCRIPTION
Reflections can take up a lot of time at application start up. This pull requests allows users to choose to build a TypesafeConfigModule using either reflections or fast-classpath-scanner.

Where using reflections might take upwards of 10 seconds with a moderately sized classpath, fast-classpath-scanner perform the same work in under a second.